### PR TITLE
New mutable sampler sampler code for Vulkan.

### DIFF
--- a/include/ht_sampler.h
+++ b/include/ht_sampler.h
@@ -26,14 +26,6 @@ namespace Hatchit {
             virtual ~ISampler() = default;
 
             virtual bool VPrepare() = 0;
-
-            virtual void SetFilterMode(Resource::Sampler::FilterMode filterMode) = 0;
-            virtual void SetWrapMode(Resource::Sampler::WrapMode wrapMode) = 0;
-            virtual void SetColorSpace(Resource::Sampler::ColorSpace colorSpace) = 0;
-            
-            virtual Resource::Sampler::FilterMode GetFilterMode() const = 0;
-            virtual Resource::Sampler::WrapMode GetWrapMode() const = 0;
-            virtual Resource::Sampler::ColorSpace GetColorSpace() const = 0;
         };
 
 		using ISamplerHandle = Core::Handle<ISampler>;

--- a/include/vulkan/ht_vksampler.h
+++ b/include/vulkan/ht_vksampler.h
@@ -34,23 +34,15 @@ namespace Hatchit {
 
                 VkSampler GetVkSampler();
 
-                // Inherited via ISampler
-                virtual void SetFilterMode(Hatchit::Resource::Sampler::FilterMode filterMode) override;
-                virtual void SetWrapMode(Hatchit::Resource::Sampler::WrapMode wrapMode) override;
-                virtual void SetColorSpace(Hatchit::Resource::Sampler::ColorSpace colorSpace) override;
-
-                virtual Hatchit::Resource::Sampler::FilterMode GetFilterMode() const override;
-                virtual Hatchit::Resource::Sampler::WrapMode GetWrapMode() const override;
-                virtual Hatchit::Resource::Sampler::ColorSpace GetColorSpace() const override;
-
             private:
-                const VkDevice& m_device;
+                const VkDevice&             m_device;
+                VkSampler                   m_sampler;
+                std::string                 m_fileName;
+                Hatchit::Resource::Sampler  m_base;
 
-                VkSampler m_sampler;
 
-                Hatchit::Resource::Sampler::FilterMode m_filterMode;
-                Hatchit::Resource::Sampler::WrapMode m_wrapMode;
-                Hatchit::Resource::Sampler::ColorSpace m_colorSpace;
+                VkSamplerAddressMode    VKAddressModeFromType(Resource::Sampler::AddressMode mode);
+                VkFilter                VKFilterModeFromType(Resource::Sampler::FilterMode mode);
             };
 
 			using VKSamplerHandle = Core::Handle<VKSampler>;

--- a/include/vulkan/ht_vksampler.h
+++ b/include/vulkan/ht_vksampler.h
@@ -33,16 +33,22 @@ namespace Hatchit {
                 bool VPrepare() override;
 
                 VkSampler GetVkSampler();
+                VkFormat  GetVkColorSpace();
 
             private:
                 const VkDevice&             m_device;
                 VkSampler                   m_sampler;
+                VkFormat                    m_colorSpace;
                 std::string                 m_fileName;
                 Hatchit::Resource::Sampler  m_base;
 
 
                 VkSamplerAddressMode    VKAddressModeFromType(Resource::Sampler::AddressMode mode);
                 VkFilter                VKFilterModeFromType(Resource::Sampler::FilterMode mode);
+                VkFormat                VKColorSpaceFromType(Resource::Sampler::ColorSpace space);
+                VkCompareOp             VKCompareOpFromType(Resource::Sampler::CompareOperation op);
+                VkSamplerMipmapMode     VKMipMapModeFromType(Resource::Sampler::MipMode mode);
+                VkBorderColor           VKBorderColorFromType(Resource::Sampler::BorderColor color);
             };
 
 			using VKSamplerHandle = Core::Handle<VKSampler>;

--- a/source/directx/dx12/ht_d3d12rootlayout.cpp
+++ b/source/directx/dx12/ht_d3d12rootlayout.cpp
@@ -211,7 +211,7 @@ namespace Hatchit
                 using namespace Resource;
 
                 std::vector<D3D12_STATIC_SAMPLER_DESC>  _descs;
-                std::vector<RootLayout::Sampler> _RootSamplers = handle->GetSamplers();
+                std::vector<Sampler> _RootSamplers = handle->GetSamplers();
                 for (auto sampler : _RootSamplers)
                 {
                     D3D12_STATIC_SAMPLER_DESC desc;

--- a/source/vulkan/ht_vktexture.cpp
+++ b/source/vulkan/ht_vktexture.cpp
@@ -69,18 +69,7 @@ namespace Hatchit {
                 VkFormat format;
                 if (m_resource->GetChannels() == 4)
                 {
-                    switch (m_sampler->GetColorSpace())
-                    {
-                    case Resource::Sampler::ColorSpace::GAMMA:
-                        format = VK_FORMAT_R8G8B8A8_SRGB;
-                        break;
-                    case Resource::Sampler::ColorSpace::LINEAR:
-                        format = VK_FORMAT_R8G8B8A8_UNORM;
-                        break;
-                    default:
-                        format = VK_FORMAT_R8G8B8A8_UNORM;
-                        break;
-                    }
+                    format = m_sampler->GetVkColorSpace();
                 }
                 else
                 {


### PR DESCRIPTION
I have refactored the VKSampler class to now use the new MutableSampler resource. I have tested these changes myself and Vulkan renders perfectly fine with the new sampler format. Please test it yourself to make sure the sampler resource are loading correctly with any upcoming changes to resource loading.